### PR TITLE
umdoni_issues#20250521-fixed the broken covid page

### DIFF
--- a/App/Controllers/Covid.php
+++ b/App/Controllers/Covid.php
@@ -22,8 +22,8 @@ class Covid extends \Core\Controller
 
     public function indexAction()
     {
-        view::render('covid/index.php', 
-        $context =[], 'default');
+      
+        view::render('covid/index.php', [], 'default');
     }
 
     /**

--- a/App/Views/covid/index.php
+++ b/App/Views/covid/index.php
@@ -93,4 +93,3 @@ $data = $context->data;
     </div>
 </div>
 </div>
-<section


### PR DESCRIPTION
umdoni_issues#20250521-fixed the broken covid page

# RCA

Issue: umdoni_issues#20250521.
Root Cause: page has a broken section tag at the end so affect the footer
Fix:  removed the section tag and fixed the link so that routing works
